### PR TITLE
Updated layout - removed feedback cta in header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,10 +28,6 @@
     <header class="page-header" role="banner">
       <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
       <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
-      {% if site.github.is_project_page %}
-      <a href="https://forms.gle/zSbFssCE4YCWYiTB8" class="btn">Provide input</a>
-        <!--<a href="{{site.github.repository_url}}/blob/gh-pages/{{page.path}}" class="btn--secondary">Edit this page</a>-->
-      {% endif %}
       {% if site.show_downloads %}
         <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>
         <a href="{{ site.github.tar_url }}" class="btn">Download .tar.gz</a>


### PR DESCRIPTION
We have the feedback CTAs on sidebar and at footer, don't think we need at the top as well.